### PR TITLE
Set Environment Var's back to how you had them

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,8 +8,8 @@ Bundler.require(*Rails.groups)
 
 # Configure Mandrill
 if Rails.env == 'production'
-  MANDRILL = { MANDRILL_USERNAME: ENV['MANDRILL_USERNAME'],
-               MANDRILL_PASSWORD: ENV['MANDRILL_PASSWORD'] }
+  MANDRILL = { MANDRILL_USERNAME: ENV['MANDRILL_USER'],
+               MANDRILL_PASSWORD: ENV['MANDRILL_PASS'] }
 else
   MANDRILL = YAML.load(File.read(File.expand_path('../mandrill.yml', __FILE__)))
   MANDRILL.merge! MANDRILL.fetch(Rails.env, {})

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,7 +16,15 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = { address: 'localhost', port: 1025 }
+  config.action_mailer.smtp_settings = { 
+    address: 'smtp.gmail.com',
+    port: "587",
+    domain: "gmail.com",
+    authentication: "plain",
+    enable_starttls_auto: true,
+    user_name: ENV["GMAIL_USERNAME_DEV"],
+    password: ENV["GMAIL_PASSWORD_DEV"] 
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,7 +17,6 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = { 
-
     :address   => "smtp.mandrillapp.com",
     :port      => 25,
     :enable_starttls_auto => true,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -21,8 +21,8 @@ Rails.application.configure do
     :address   => "smtp.mandrillapp.com",
     :port      => 25,
     :enable_starttls_auto => true,
-    :user_name => 'derek.covey@gmail.com', # 'derek.covey@gmail.com',
-    :password  => 'Bi7pe9S01JW7ockIbQ9smQ', # 'Bi7pe9S01JW7ockIbQ9smQ',
+    :user_name => MANDRILL[:MANDRILL_USERNAME], # 'derek.covey@gmail.com',
+    :password  => MANDRILL[:MANDRILL_PASSWORD], # 'Bi7pe9S01JW7ockIbQ9smQ',
     :authentication => 'login',
     :domain => 'mandrillapp.com'
     }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,16 +17,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = { 
-<<<<<<< HEAD
-    address: 'smtp.gmail.com',
-    port: "587",
-    domain: "gmail.com",
-    authentication: "plain",
-    enable_starttls_auto: true,
-    user_name: ENV["GMAIL_USERNAME_DEV"],
-    password: ENV["GMAIL_PASSWORD_DEV"] 
-  }
-=======
+
     :address   => "smtp.mandrillapp.com",
     :port      => 25,
     :enable_starttls_auto => true,
@@ -35,7 +26,6 @@ Rails.application.configure do
     :authentication => 'login',
     :domain => 'mandrillapp.com'
     }
->>>>>>> upstream/master
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -21,8 +21,8 @@ Rails.application.configure do
     :address   => "smtp.mandrillapp.com",
     :port      => 25,
     :enable_starttls_auto => true,
-    :user_name => MANDRILL[:MANDRILL_USERNAME], # 'derek.covey@gmail.com',
-    :password  => MANDRILL[:MANDRILL_PASSWORD], # 'Bi7pe9S01JW7ockIbQ9smQ',
+    :user_name => 'derek.covey@gmail.com', # 'derek.covey@gmail.com',
+    :password  => 'Bi7pe9S01JW7ockIbQ9smQ', # 'Bi7pe9S01JW7ockIbQ9smQ',
     :authentication => 'login',
     :domain => 'mandrillapp.com'
     }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,8 +19,8 @@ Rails.application.configure do
     :address   => "smtp.mandrillapp.com",
     :port      => 25,
     :enable_starttls_auto => true,
-    :user_name => 'derek.covey@gmail.com',
-    :password  => 'Bi7pe9S01JW7ockIbQ9smQ',
+    :user_name => MANDRILL[:MANDRILL_USERNAME],
+    :password  => MANDRILL[:MANDRILL_PASSWORD],
     :authentication => 'login',
     :domain => 'mandrillapp.com',
   }


### PR DESCRIPTION
Was working with one of the mailers and messed with the environmental Mandrill variables and ran into issues.  Reverting them back to how they were.
